### PR TITLE
cobaltcr ICE improvements

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1004,7 +1004,7 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_l
         return MAV_RESULT_ACCEPTED;
 
     case MAV_CMD_DO_ENGINE_CONTROL:
-        if (!plane.g2.ice_control.engine_control(packet.param1, packet.param2, packet.param3)) {
+        if (!plane.g2.ice_control.engine_control(packet.param1, packet.param2, packet.param3, packet.param4)) {
             return MAV_RESULT_FAILED;
         }
         return MAV_RESULT_ACCEPTED;

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -189,7 +189,8 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
     case MAV_CMD_DO_ENGINE_CONTROL:
         plane.g2.ice_control.engine_control(cmd.content.do_engine_control.start_control,
                                             cmd.content.do_engine_control.cold_start,
-                                            cmd.content.do_engine_control.height_delay_cm*0.01f);
+                                            cmd.content.do_engine_control.height_delay_cm*0.01f,
+                                            0);
         break;
 
     default:

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1261,7 +1261,7 @@ void QuadPlane::control_loiter()
             poscontrol.state = QPOS_LAND_FINAL;
             // cut IC engine if enabled
             if (land_icengine_cut != 0) {
-                plane.g2.ice_control.engine_control(0, 0, 0);
+                plane.g2.ice_control.engine_control(0, 0, 0, 0);
             }
         }
         float height_above_ground = plane.relative_ground_altitude(plane.g.rangefinder_landing);
@@ -2814,7 +2814,7 @@ bool QuadPlane::verify_vtol_land(void)
 
         // cut IC engine if enabled
         if (land_icengine_cut != 0) {
-            plane.g2.ice_control.engine_control(0, 0, 0);
+            plane.g2.ice_control.engine_control(0, 0, 0, 0);
         }
         gcs().send_text(MAV_SEVERITY_INFO,"Land final started");
     }

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -36,7 +36,7 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
 
     // @Param: START_CHAN
     // @DisplayName: Input channel for engine start
-    // @Description: This is an RC input channel for requesting engine start. Engine will try to start when channel is at or above 1700. Engine will stop when channel is at or below 1300. Between 1301 and 1699 the engine will not change state unless a MAVLink command or mission item commands a state change, or the vehicle is disamed.
+    // @Description: This is an RC input channel for requesting engine start. Engine will try to start when channel is at or above 1700. Engine will stop when channel is at or below 1300. Between 1301 and 1699 the engine will not change state unless a MAVLink command or mission item commands a state change, or the vehicle is disamed. See ICE_STARTCHN_MIN parameter to change engine stop PWM value and/or to enable debouncing of the START_CH to avoid accidental engine kills due to noise on channel.
     // @User: Standard
     // @Values: 0:None,1:Chan1,2:Chan2,3:Chan3,4:Chan4,5:Chan5,6:Chan6,7:Chan7,8:Chan8,9:Chan9,10:Chan10,11:Chan11,12:Chan12,13:Chan13,14:Chan14,15:Chan15,16:Chan16
     AP_GROUPINFO("START_CHAN", 1, AP_ICEngine, start_chan, 0),

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -216,6 +216,11 @@ void AP_ICEngine::update(void)
         should_run = false;
     }
 
+    if ((options & uint16_t(Options::NO_STARTING_WHILE_DISARMED)) && !hal.util->get_soft_armed()) {
+        // no starting while disarmed
+        should_run = false;
+    }
+
     // switch on current state to work out new state
     switch (state) {
     case ICE_OFF:

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -382,6 +382,9 @@ bool AP_ICEngine::engine_control(float start_control, float cold_start, float he
 */
 void AP_ICEngine::update_idle_governor(int8_t &min_throttle)
 {
+    if (!enable) {
+        return;
+    }
     const int8_t min_throttle_base = min_throttle;
 
     // Initialize idle poing to min_throttle on the first run

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -134,7 +134,14 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
     // @Description: Options for ICE control
     // @Bitmask: 0:DisableIgnitionRCFailsafe
     AP_GROUPINFO("OPTIONS", 15, AP_ICEngine, options, 0),
-    
+
+    // @Param: STARTCHN_MIN
+    // @DisplayName: Input channel for engine start minimum PWM
+    // @Description: This is a minimum PWM value for engine start channel for an engine stop to be commanded. Setting this value will avoid RC input glitches with low PWM values from causing an unwanted engine stop. A value of zero means any PWM below 1300 triggers an engine stop.
+    // @User: Standard
+    // @Range: 0 1300
+    AP_GROUPINFO("STARTCHN_MIN", 16, AP_ICEngine, start_chan_min_pwm, 0),
+
     AP_GROUPEND
 };
 
@@ -165,6 +172,10 @@ void AP_ICEngine::update(void)
     if (c != nullptr) {
         // get starter control channel
         cvalue = c->get_radio_in();
+
+        if (cvalue < start_chan_min_pwm) {
+            cvalue = start_chan_last_value;
+        }
 
         // snap the input to either 1000, 1500, or 2000
         // this is useful to compare a debounce changed value
@@ -347,7 +358,8 @@ bool AP_ICEngine::engine_control(float start_control, float cold_start, float he
     RC_Channel *c = rc().channel(start_chan-1);
     if (c != nullptr) {
         // get starter control channel
-        if (c->get_radio_in() <= 1300) {
+        uint16_t cvalue = c->get_radio_in();
+        if (cvalue >= start_chan_min_pwm && cvalue <= 1300) {
             gcs().send_text(MAV_SEVERITY_INFO, "Engine: start control disabled");
             return false;
         }

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -169,7 +169,7 @@ void AP_ICEngine::update(void)
 
     uint16_t cvalue = 1500;
     RC_Channel *c = rc().channel(start_chan-1);
-    if (c != nullptr) {
+    if (c != nullptr && rc().has_valid_input()) {
         // get starter control channel
         cvalue = c->get_radio_in();
 
@@ -356,7 +356,7 @@ bool AP_ICEngine::engine_control(float start_control, float cold_start, float he
         return true;
     }
     RC_Channel *c = rc().channel(start_chan-1);
-    if (c != nullptr) {
+    if (c != nullptr && rc().has_valid_input()) {
         // get starter control channel
         uint16_t cvalue = c->get_radio_in();
         if (cvalue >= start_chan_min_pwm && cvalue <= 1300) {

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -119,7 +119,7 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("IDLE_RPM", 12, AP_ICEngine, idle_rpm, -1),
 
-    // @Param: ICE_IDLE_DB
+    // @Param: IDLE_DB
     // @DisplayName: Deadband for Idle Governor
     // @Description: This configures the deadband that is tolerated before adjusting the idle setpoint
     AP_GROUPINFO("IDLE_DB", 13, AP_ICEngine, idle_db, 50),

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -18,6 +18,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Scheduler/AP_Scheduler.h>
+#include <AP_Notify/AP_Notify.h>
 #include "AP_ICEngine.h"
 
 extern const AP_HAL::HAL& hal;
@@ -128,6 +129,12 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
     // @Description: This configures the slewrate used to adjust the idle setpoint in percentage points per second
     AP_GROUPINFO("IDLE_SLEW", 14, AP_ICEngine, idle_slew, 1),
 
+    // @Param: OPTIONS
+    // @DisplayName: ICE options
+    // @Description: Options for ICE control
+    // @Bitmask: 0:DisableIgnitionRCFailsafe
+    AP_GROUPINFO("OPTIONS", 15, AP_ICEngine, options, 0),
+    
     AP_GROUPEND
 };
 
@@ -191,6 +198,11 @@ void AP_ICEngine::update(void)
         should_run = false;
     } else if (state != ICE_OFF) {
         should_run = true;
+    }
+
+    if ((options & uint16_t(Options::DISABLE_IGNITION_RC_FAILSAFE)) && AP_Notify::flags.failsafe_radio) {
+        // user has requested ignition kill on RC failsafe
+        should_run = false;
     }
 
     // switch on current state to work out new state

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -66,6 +66,9 @@ private:
     // channel for pilot to command engine start, 0 for none
     AP_Int8 start_chan;
 
+    // min pwm on start channel for engine stop
+    AP_Int16 start_chan_min_pwm;
+    
     // which RPM instance to use
     AP_Int8 rpm_instance;
     

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -46,7 +46,7 @@ public:
     ICE_State get_state(void) const { return state; }
 
     // handle DO_ENGINE_CONTROL messages via MAVLink or mission
-    bool engine_control(float start_control, float cold_start, float height_delay);
+    bool engine_control(float start_control, float cold_start, float height_delay, float allow_disarmed);
 
     // update min throttle for idle governor
     void update_idle_governor(int8_t &min_throttle);
@@ -116,6 +116,8 @@ private:
 
     // we are waiting for valid height data
     bool height_pending:1;
+
+    bool allow_single_start_while_disarmed;
 
     // idle governor
     float idle_governor_integrator;

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -121,7 +121,8 @@ private:
     float idle_governor_integrator;
 
     enum class Options : uint16_t {
-        DISABLE_IGNITION_RC_FAILSAFE=(1U<<0),
+        DISABLE_IGNITION_RC_FAILSAFE = (1U<<0),
+        NO_STARTING_WHILE_DISARMED   = (1U<<1),
     };
     AP_Int16 options;
 

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -117,6 +117,11 @@ private:
     // idle governor
     float idle_governor_integrator;
 
+    enum class Options : uint16_t {
+        DISABLE_IGNITION_RC_FAILSAFE=(1U<<0),
+    };
+    AP_Int16 options;
+
     // start_chan debounce
     uint16_t start_chan_last_value = 1500;
     uint32_t start_chan_last_ms;


### PR DESCRIPTION
This adds `ICE_OPTIONS` parameter (and several other commits) from master. If options is set to 2 then the engine won't be startable while disarmed. Then it adds to the command long `ENGINE_CONTROL` param4 as a flag to allow a single start while disarmed.