### PR TITLE
Wickedshell/cobaltcr vtol battery crossceck

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -441,6 +441,9 @@ private:
           TILT_TYPE_BICOPTER      =3
     };
 
+    uint32_t last_passed_current_check_ms;
+    AP_Float motor_failure_current_high_threshold;
+
     // tiltrotor control variables
     struct {
         AP_Int16 tilt_mask;

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -361,7 +361,8 @@ class sitl(Board):
         )
 
         env.CXXFLAGS += [
-            '-Werror=float-equal'
+            '-Werror=float-equal',
+            '-Wno-maybe-uninitialized'
         ]
 
         if not cfg.env.DEBUG:


### PR DESCRIPTION
Plane: Support checking if the batteries are out of balance on CR

This is an incredibly assertive check. It will keep forcing you into
QLAND, and it can't be disabled at runtime. The thresholds are all hard
coded as well, which is an obvious future problem.